### PR TITLE
Add 42StBryPark to ny.7.wpt

### DIFF
--- a/data/NY/usanycs/ny.7.wpt
+++ b/data/NY/usanycs/ny.7.wpt
@@ -1,6 +1,7 @@
 34StHudYar http://www.openstreetmap.org/?lat=40.756173&lon=-74.001632
 +X122576 http://www.openstreetmap.org/?lat=40.759513&lon=-73.998145
 42StTimSq http://www.openstreetmap.org/?lat=40.755888&lon=-73.986697
+42StBryPark http://www.openstreetmap.org/?lat=40.754694&lon=-73.984144
 5Ave http://www.openstreetmap.org/?lat=40.753820&lon=-73.982170
 42StGraCen http://www.openstreetmap.org/?lat=40.752406&lon=-73.977470
 VerBlvdJacAve http://www.openstreetmap.org/?lat=40.742693&lon=-73.954114


### PR DESCRIPTION
Add missing stop, 42 St-Bryant Park, to the 7 line of the New York City Subway (already present in B/D/F/M waypoint files).