### PR TITLE
NW

### DIFF
--- a/data/DEU-NW/deurrt/deunw.705dus.wpt
+++ b/data/DEU-NW/deurrt/deunw.705dus.wpt
@@ -23,8 +23,7 @@ FarStr http://www.openstreetmap.org/?lat=51.208893&lon=6.782534
 KarPla http://www.openstreetmap.org/?lat=51.204756&lon=6.780281
 KopStr_1 http://www.openstreetmap.org/?lat=51.202521&lon=6.780603
 +DIV_SteA http://www.openstreetmap.org/?lat=51.200030&lon=6.781740
-SteBurg http://www.openstreetmap.org/?lat=51.199849&lon=6.780742
-MerStr http://www.openstreetmap.org/?lat=51.200359&lon=6.777577
+SteMerStr http://www.openstreetmap.org/?lat=51.200134&lon=6.778843
 MerPla http://www.openstreetmap.org/?lat=51.198571&lon=6.777738
 MooStr http://www.openstreetmap.org/?lat=51.198874&lon=6.782244
 +DIV_SteB http://www.openstreetmap.org/?lat=51.200030&lon=6.781740

--- a/data/DEU-NW/deurrt/deunw.706dus.wpt
+++ b/data/DEU-NW/deurrt/deunw.706dus.wpt
@@ -35,8 +35,7 @@ RedStr http://www.openstreetmap.org/?lat=51.205912&lon=6.788392
 Hen http://www.openstreetmap.org/?lat=51.202995&lon=6.783017
 KopStr_1 http://www.openstreetmap.org/?lat=51.202521&lon=6.780603
 +DIV_SteA http://www.openstreetmap.org/?lat=51.200030&lon=6.781740
-SteBurg http://www.openstreetmap.org/?lat=51.199849&lon=6.780742
-MerStr http://www.openstreetmap.org/?lat=51.200359&lon=6.777577
+SteMerStr http://www.openstreetmap.org/?lat=51.200134&lon=6.778843
 MerPla http://www.openstreetmap.org/?lat=51.198571&lon=6.777738
 MooStr http://www.openstreetmap.org/?lat=51.198874&lon=6.782244
 +DIV_SteB http://www.openstreetmap.org/?lat=51.200030&lon=6.781740


### PR DESCRIPTION
'Am Steinberg' is the end of 705 and 706 (all passengers have to exit), Merowingerstraße is the first stop after drivers had a break before starting the next loop. I arrived with 706, walked to Merowingerstraße, and entered the very same train that took over the 705 route now. Thus, I've merged the stops into one.