### PR TITLE
MD/PRT

### DIFF
--- a/data/ESP-MD/espmm/espmd.m5.wpt
+++ b/data/ESP-MD/espmm/espmd.m5.wpt
@@ -9,6 +9,7 @@ Opo http://www.openstreetmap.org/?lat=40.388675&lon=-3.731661
 Urg http://www.openstreetmap.org/?lat=40.392597&lon=-3.725395
 MarVad http://www.openstreetmap.org/?lat=40.397434&lon=-3.716426
 Pir http://www.openstreetmap.org/?lat=40.402606&lon=-3.711373
+Aca http://www.openstreetmap.org/?lat=40.404097&lon=-3.705922
 PueTol http://www.openstreetmap.org/?lat=40.407006&lon=-3.711061
 Lat http://www.openstreetmap.org/?lat=40.411286&lon=-3.708326
 Ope http://www.openstreetmap.org/?lat=40.418001&lon=-3.709420

--- a/data/PRT/prtpm/prt.d.wpt
+++ b/data/PRT/prtpm/prt.d.wpt
@@ -14,3 +14,6 @@ CamGaia http://www.openstreetmap.org/?lat=41.129654&lon=-8.606168
 JoaoDeus http://www.openstreetmap.org/?lat=41.126072&lon=-8.605621
 DomJoaoII http://www.openstreetmap.org/?lat=41.119525&lon=-8.606157
 SanOvi http://www.openstreetmap.org/?lat=41.115451&lon=-8.606565
+ManLeao http://www.openstreetmap.org/?lat=41.110646&lon=-8.600042
+HosSanSil http://www.openstreetmap.org/?lat=41.105820&lon=-8.591148
+VilaEste http://www.openstreetmap.org/?lat=41.098615&lon=-8.588524


### PR DESCRIPTION
Madrid's M5 missed a station.
Porto's D was extended in June 2024: https://pt.wikipedia.org/wiki/Linha_D_(Metro_do_Porto)